### PR TITLE
Add docker compose (mysql)

### DIFF
--- a/compose.yml
+++ b/compose.yml
@@ -1,0 +1,19 @@
+version: "3.9"
+
+services:
+  mysql:
+    image: mysql:8
+    container_name: mysql
+    ports:
+      - "13306:3306"
+    environment:
+      MYSQL_ROOT_PASSWORD: password
+      MYSQL_DATABASE: mydatabase
+      MYSQL_USER: user
+      MYSQL_PASSWORD: password
+    volumes:
+      - ./docker/mysql/conf/my.cnf:/etc/mysql/conf.d/my.cnf
+      - mysql_data:/var/lib/mysql
+
+volumes:
+  mysql_data:

--- a/docker/mysql/conf/my.cnf
+++ b/docker/mysql/conf/my.cnf
@@ -1,0 +1,4 @@
+[mysqld]
+datadir = /var/lib/mysql
+character-set-server = utf8mb4
+collation-server = utf8mb4_unicode_ci


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Introduced a Docker-based configuration to deploy and manage a MySQL service (version 8), including port mapping and environment variable setup for database credentials and initialization.
  - Added a custom MySQL configuration to establish specific server settings such as the data directory, character set, and collation for improved performance and consistency.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->