### PR TITLE
fix: issue37: sqluv binary release has the binary named as sqly

### DIFF
--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -1,4 +1,4 @@
-project_name: sqly
+project_name: sqluv
 env:
   - GO111MODULE=on
 before:

--- a/config/database.go
+++ b/config/database.go
@@ -269,7 +269,7 @@ func NewSQLServerDB(config SQLServerConfig) (SQLServerDB, func(), error) {
 	return SQLServerDB(db), func() { db.Close() }, nil
 }
 
-// HistoryDB is *sql.DB for sqly shell history.
+// HistoryDB is *sql.DB for sqluv shell history.
 type HistoryDB *sql.DB
 
 // NewHistoryDB create *sql.DB for history.

--- a/domain/errors.go
+++ b/domain/errors.go
@@ -1,4 +1,4 @@
-// Package domain manage sqly domain logic.
+// Package domain manage sqluv domain logic.
 package domain
 
 import "errors"

--- a/domain/model/history.go
+++ b/domain/model/history.go
@@ -4,14 +4,14 @@ import (
 	"strconv"
 )
 
-// Histories is sqly history all record.
+// Histories is sqluv history all record.
 type Histories []History
 
-// History is sqly history record.
+// History is sqluv history record.
 type History struct {
 	// ID is history id. 1 is oldest
 	ID int
-	// Request is sqly history record that is user input from sqly prompt
+	// Request is sqluv history record that is user input from sqluv prompt
 	Request string
 }
 

--- a/domain/repository/history.go
+++ b/domain/repository/history.go
@@ -9,9 +9,9 @@ import (
 //go:generate mockgen -typed -source=$GOFILE -destination=../../infrastructure/mock/$GOFILE -package mock
 
 type (
-	// HistoryTableCreator is a repository that creates a table for sqly shell history.
+	// HistoryTableCreator is a repository that creates a table for sqluv shell history.
 	HistoryTableCreator interface {
-		// CreateTable create a DB table for sqly shell history
+		// CreateTable create a DB table for sqluv shell history
 		CreateTable(ctx context.Context) error
 	}
 

--- a/infrastructure/persistence/history.go
+++ b/infrastructure/persistence/history.go
@@ -24,7 +24,7 @@ func NewHistoryTableCreator(db config.HistoryDB) repository.HistoryTableCreator 
 	}
 }
 
-// CreateTable create a DB table for sqly shell history
+// CreateTable create a DB table for sqluv shell history
 func (h *historyTableCreator) CreateTable(ctx context.Context) error {
 	tx, err := h.db.BeginTx(ctx, nil)
 	if err != nil {

--- a/interactor/history.go
+++ b/interactor/history.go
@@ -20,7 +20,7 @@ func NewHistoryTableCreator(r repository.HistoryTableCreator) usecase.HistoryTab
 	return &historyTableCreator{r: r}
 }
 
-// CreateTable create table for sqly history.
+// CreateTable create table for sqluv history.
 func (hi *historyTableCreator) CreateTable(ctx context.Context) error {
 	return hi.r.CreateTable(ctx)
 }


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Chores**
  - Updated the project’s identifier to the new name across configurations and settings.
  
- **Documentation**
  - Revised all descriptive text and references in documentation to ensure consistency with the updated project name.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->