### PR TITLE
fix: issue 36: Unable to connect to mysql with native password

### DIFF
--- a/config/database.go
+++ b/config/database.go
@@ -103,13 +103,14 @@ func NewMySQLConfig(
 // The return function is the function to close the DB.
 func NewMySQLDB(config MySQLConfig) (MySQLDB, func(), error) {
 	c := mysql.Config{
-		DBName:    config.database,
-		User:      config.user,
-		Passwd:    config.password,
-		Addr:      fmt.Sprintf("%s:%d", config.host, config.port),
-		Net:       "tcp",
-		ParseTime: true,
-		Collation: "utf8mb4_unicode_ci",
+		DBName:               config.database,
+		User:                 config.user,
+		Passwd:               config.password,
+		Addr:                 fmt.Sprintf("%s:%d", config.host, config.port),
+		Net:                  "tcp",
+		ParseTime:            true,
+		Collation:            "utf8mb4_unicode_ci",
+		AllowNativePasswords: true,
 	}
 
 	db, err := sql.Open("mysql", c.FormatDSN())


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Enhanced MySQL connectivity by enabling native password authentication, which can improve compatibility and reliability.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->