### PR TITLE
add: execute "SELECT * FROM ${TABLE_NAME} LIMIT 100"

### DIFF
--- a/README.md
+++ b/README.md
@@ -63,6 +63,10 @@ If the connection is successful, database connection information will be saved i
 
 ![home_screen](doc/image/dbms_home.png)
 
+### Execute SQL query
+
+To execute a SQL query, enter the SQL query in the query text area and press the execute button or `Ctrl + e`. When you select the table name on the sidebar and press the `Ctrl + e`, the sqluv executes the `SELECT * FROM ${TABLE_NAME} LIMIT 100` query.
+
 ## SQL query history
 
 If you execute a SQL query, the history will be saved in the `~/.config/sqluv/history.db`. So, you can look up the history by pressing the history button.

--- a/tui/tui.go
+++ b/tui/tui.go
@@ -408,6 +408,17 @@ func (t *TUI) keyBindings(event *tcell.EventKey) *tcell.EventKey {
 			t.executeQuery(context.Background())
 			return nil
 		}
+		if t.home.sidebar.HasFocus() {
+			node := t.home.sidebar.GetCurrentNode()
+			if node != nil {
+				if table, ok := node.GetReference().(*model.Table); ok {
+					query := fmt.Sprintf("SELECT * FROM %s LIMIT 100", table.Name())
+					t.home.queryTextArea.SetText(query, true)
+					t.executeQuery(context.Background())
+					return nil
+				}
+			}
+		}
 	case event.Key() == tcell.KeyCtrlH:
 		t.showHistoryList()
 		return nil


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Introduced a quick SQL query execution feature allowing users to run queries by pressing Ctrl+E when a table is selected from the sidebar.
- **Documentation**
  - Added a new "Execute SQL query" section in the README.md, detailing how to execute SQL queries within the interface.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->