### PR TITLE
fix: get ddl in memory sqlite3

### DIFF
--- a/di/wire_gen.go
+++ b/di/wire_gen.go
@@ -40,6 +40,8 @@ func NewSqluv(ctx context.Context, arg *config.Argument) (*tui.TUI, func(), erro
 	usecaseTableCreator := interactor.NewTableCreator(tableCreator)
 	tablesGetter := memory.NewTableGetter(memoryDB)
 	usecaseTablesGetter := interactor.NewLocalTablesGetter(tablesGetter)
+	tableDDLGetter := memory.NewTableDDLGetter(memoryDB)
+	usecaseTableDDLGetter := interactor.NewTableDDLGetter(tableDDLGetter)
 	queryExecutor := memory.NewQueryExecutor(memoryDB)
 	statementExecutor := memory.NewStatementExecutor(memoryDB)
 	sqlExecutor := interactor.NewSQLExecutor(queryExecutor, statementExecutor)
@@ -67,7 +69,7 @@ func NewSqluv(ctx context.Context, arg *config.Argument) (*tui.TUI, func(), erro
 		cleanup()
 		return nil, nil, err
 	}
-	tuiTUI := tui.NewTUI(arg, fileReader, fileWriter, usecaseTableCreator, usecaseTablesGetter, sqlExecutor, usecaseRecordsInserter, usecaseHistoryTableCreator, usecaseHistoryCreator, usecaseHistoryLister, dbConfig, colorConfig)
+	tuiTUI := tui.NewTUI(arg, fileReader, fileWriter, usecaseTableCreator, usecaseTablesGetter, usecaseTableDDLGetter, sqlExecutor, usecaseRecordsInserter, usecaseHistoryTableCreator, usecaseHistoryCreator, usecaseHistoryLister, dbConfig, colorConfig)
 	return tuiTUI, func() {
 		cleanup2()
 		cleanup()

--- a/domain/repository/in_memory.go
+++ b/domain/repository/in_memory.go
@@ -33,4 +33,9 @@ type (
 	StatementExecutor interface {
 		ExecuteStatement(ctx context.Context, sql *model.SQL) (int64, error)
 	}
+
+	// TableDDLGetter gets a table's DDL information.
+	TableDDLGetter interface {
+		GetTableDDL(ctx context.Context, tableName string) ([]*model.Table, error)
+	}
 )

--- a/domain/repository/persistence.go
+++ b/domain/repository/persistence.go
@@ -24,9 +24,9 @@ type (
 		GetTables(ctx context.Context) ([]*model.Table, error)
 	}
 
-	// TableDDLGetter is an interface for retrieving a table's DDL information,
+	// TableDDLInRemoteGetter is an interface for retrieving a table's DDL information,
 	// including columns, data types, precision, nullability, default values, primary key status, etc.
-	TableDDLGetter interface {
+	TableDDLInRemoteGetter interface {
 		GetTableDDL(ctx context.Context, tableName string) ([]*model.Table, error)
 	}
 )

--- a/infrastructure/memory/wire.go
+++ b/infrastructure/memory/wire.go
@@ -10,4 +10,5 @@ var Set = wire.NewSet(
 	NewRecordInserter,
 	NewQueryExecutor,
 	NewStatementExecutor,
+	NewTableDDLGetter,
 )

--- a/infrastructure/mock/in_memory.go
+++ b/infrastructure/mock/in_memory.go
@@ -329,3 +329,66 @@ func (c *MockStatementExecutorExecuteStatementCall) DoAndReturn(f func(context.C
 	c.Call = c.Call.DoAndReturn(f)
 	return c
 }
+
+// MockTableDDLGetter is a mock of TableDDLGetter interface.
+type MockTableDDLGetter struct {
+	ctrl     *gomock.Controller
+	recorder *MockTableDDLGetterMockRecorder
+	isgomock struct{}
+}
+
+// MockTableDDLGetterMockRecorder is the mock recorder for MockTableDDLGetter.
+type MockTableDDLGetterMockRecorder struct {
+	mock *MockTableDDLGetter
+}
+
+// NewMockTableDDLGetter creates a new mock instance.
+func NewMockTableDDLGetter(ctrl *gomock.Controller) *MockTableDDLGetter {
+	mock := &MockTableDDLGetter{ctrl: ctrl}
+	mock.recorder = &MockTableDDLGetterMockRecorder{mock}
+	return mock
+}
+
+// EXPECT returns an object that allows the caller to indicate expected use.
+func (m *MockTableDDLGetter) EXPECT() *MockTableDDLGetterMockRecorder {
+	return m.recorder
+}
+
+// GetTableDDL mocks base method.
+func (m *MockTableDDLGetter) GetTableDDL(ctx context.Context, tableName string) ([]*model.Table, error) {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "GetTableDDL", ctx, tableName)
+	ret0, _ := ret[0].([]*model.Table)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
+}
+
+// GetTableDDL indicates an expected call of GetTableDDL.
+func (mr *MockTableDDLGetterMockRecorder) GetTableDDL(ctx, tableName any) *MockTableDDLGetterGetTableDDLCall {
+	mr.mock.ctrl.T.Helper()
+	call := mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetTableDDL", reflect.TypeOf((*MockTableDDLGetter)(nil).GetTableDDL), ctx, tableName)
+	return &MockTableDDLGetterGetTableDDLCall{Call: call}
+}
+
+// MockTableDDLGetterGetTableDDLCall wrap *gomock.Call
+type MockTableDDLGetterGetTableDDLCall struct {
+	*gomock.Call
+}
+
+// Return rewrite *gomock.Call.Return
+func (c *MockTableDDLGetterGetTableDDLCall) Return(arg0 []*model.Table, arg1 error) *MockTableDDLGetterGetTableDDLCall {
+	c.Call = c.Call.Return(arg0, arg1)
+	return c
+}
+
+// Do rewrite *gomock.Call.Do
+func (c *MockTableDDLGetterGetTableDDLCall) Do(f func(context.Context, string) ([]*model.Table, error)) *MockTableDDLGetterGetTableDDLCall {
+	c.Call = c.Call.Do(f)
+	return c
+}
+
+// DoAndReturn rewrite *gomock.Call.DoAndReturn
+func (c *MockTableDDLGetterGetTableDDLCall) DoAndReturn(f func(context.Context, string) ([]*model.Table, error)) *MockTableDDLGetterGetTableDDLCall {
+	c.Call = c.Call.DoAndReturn(f)
+	return c
+}

--- a/infrastructure/mock/persistence.go
+++ b/infrastructure/mock/persistence.go
@@ -206,32 +206,32 @@ func (c *MockTablesInRemoteGetterGetTablesCall) DoAndReturn(f func(context.Conte
 	return c
 }
 
-// MockTableDDLGetter is a mock of TableDDLGetter interface.
-type MockTableDDLGetter struct {
+// MockTableDDLInRemoteGetter is a mock of TableDDLInRemoteGetter interface.
+type MockTableDDLInRemoteGetter struct {
 	ctrl     *gomock.Controller
-	recorder *MockTableDDLGetterMockRecorder
+	recorder *MockTableDDLInRemoteGetterMockRecorder
 	isgomock struct{}
 }
 
-// MockTableDDLGetterMockRecorder is the mock recorder for MockTableDDLGetter.
-type MockTableDDLGetterMockRecorder struct {
-	mock *MockTableDDLGetter
+// MockTableDDLInRemoteGetterMockRecorder is the mock recorder for MockTableDDLInRemoteGetter.
+type MockTableDDLInRemoteGetterMockRecorder struct {
+	mock *MockTableDDLInRemoteGetter
 }
 
-// NewMockTableDDLGetter creates a new mock instance.
-func NewMockTableDDLGetter(ctrl *gomock.Controller) *MockTableDDLGetter {
-	mock := &MockTableDDLGetter{ctrl: ctrl}
-	mock.recorder = &MockTableDDLGetterMockRecorder{mock}
+// NewMockTableDDLInRemoteGetter creates a new mock instance.
+func NewMockTableDDLInRemoteGetter(ctrl *gomock.Controller) *MockTableDDLInRemoteGetter {
+	mock := &MockTableDDLInRemoteGetter{ctrl: ctrl}
+	mock.recorder = &MockTableDDLInRemoteGetterMockRecorder{mock}
 	return mock
 }
 
 // EXPECT returns an object that allows the caller to indicate expected use.
-func (m *MockTableDDLGetter) EXPECT() *MockTableDDLGetterMockRecorder {
+func (m *MockTableDDLInRemoteGetter) EXPECT() *MockTableDDLInRemoteGetterMockRecorder {
 	return m.recorder
 }
 
 // GetTableDDL mocks base method.
-func (m *MockTableDDLGetter) GetTableDDL(ctx context.Context, tableName string) ([]*model.Table, error) {
+func (m *MockTableDDLInRemoteGetter) GetTableDDL(ctx context.Context, tableName string) ([]*model.Table, error) {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "GetTableDDL", ctx, tableName)
 	ret0, _ := ret[0].([]*model.Table)
@@ -240,31 +240,31 @@ func (m *MockTableDDLGetter) GetTableDDL(ctx context.Context, tableName string) 
 }
 
 // GetTableDDL indicates an expected call of GetTableDDL.
-func (mr *MockTableDDLGetterMockRecorder) GetTableDDL(ctx, tableName any) *MockTableDDLGetterGetTableDDLCall {
+func (mr *MockTableDDLInRemoteGetterMockRecorder) GetTableDDL(ctx, tableName any) *MockTableDDLInRemoteGetterGetTableDDLCall {
 	mr.mock.ctrl.T.Helper()
-	call := mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetTableDDL", reflect.TypeOf((*MockTableDDLGetter)(nil).GetTableDDL), ctx, tableName)
-	return &MockTableDDLGetterGetTableDDLCall{Call: call}
+	call := mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetTableDDL", reflect.TypeOf((*MockTableDDLInRemoteGetter)(nil).GetTableDDL), ctx, tableName)
+	return &MockTableDDLInRemoteGetterGetTableDDLCall{Call: call}
 }
 
-// MockTableDDLGetterGetTableDDLCall wrap *gomock.Call
-type MockTableDDLGetterGetTableDDLCall struct {
+// MockTableDDLInRemoteGetterGetTableDDLCall wrap *gomock.Call
+type MockTableDDLInRemoteGetterGetTableDDLCall struct {
 	*gomock.Call
 }
 
 // Return rewrite *gomock.Call.Return
-func (c *MockTableDDLGetterGetTableDDLCall) Return(arg0 []*model.Table, arg1 error) *MockTableDDLGetterGetTableDDLCall {
+func (c *MockTableDDLInRemoteGetterGetTableDDLCall) Return(arg0 []*model.Table, arg1 error) *MockTableDDLInRemoteGetterGetTableDDLCall {
 	c.Call = c.Call.Return(arg0, arg1)
 	return c
 }
 
 // Do rewrite *gomock.Call.Do
-func (c *MockTableDDLGetterGetTableDDLCall) Do(f func(context.Context, string) ([]*model.Table, error)) *MockTableDDLGetterGetTableDDLCall {
+func (c *MockTableDDLInRemoteGetterGetTableDDLCall) Do(f func(context.Context, string) ([]*model.Table, error)) *MockTableDDLInRemoteGetterGetTableDDLCall {
 	c.Call = c.Call.Do(f)
 	return c
 }
 
 // DoAndReturn rewrite *gomock.Call.DoAndReturn
-func (c *MockTableDDLGetterGetTableDDLCall) DoAndReturn(f func(context.Context, string) ([]*model.Table, error)) *MockTableDDLGetterGetTableDDLCall {
+func (c *MockTableDDLInRemoteGetterGetTableDDLCall) DoAndReturn(f func(context.Context, string) ([]*model.Table, error)) *MockTableDDLInRemoteGetterGetTableDDLCall {
 	c.Call = c.Call.DoAndReturn(f)
 	return c
 }

--- a/infrastructure/persistence/dbms.go
+++ b/infrastructure/persistence/dbms.go
@@ -201,7 +201,7 @@ func NewTableDDLGetter(
 	db *sql.DB,
 	database string,
 	dbmsType config.DBMSType,
-) repository.TableDDLGetter {
+) repository.TableDDLInRemoteGetter {
 	return &ddlGetter{
 		db:       db,
 		database: database,
@@ -289,6 +289,9 @@ func (d *ddlGetter) GetTableDDL(ctx context.Context, tableName string) ([]*model
 				colName, dataType, strconv.Itoa(precision), nullable, dfltValue, columnKey,
 			}))
 		}
+	}
+	if err := rows.Err(); err != nil {
+		return nil, err
 	}
 
 	ddlTable := model.NewTable(tableName, header, records)

--- a/interactor/in_memory.go
+++ b/interactor/in_memory.go
@@ -105,3 +105,24 @@ func (r *sqlExecutor) ExecuteSQL(ctx context.Context, sql *model.SQL) (*usecase.
 	}
 	return usecase.NewExecuteSQLOutput(nil, rowsAffected), nil
 }
+
+// _ interface implementation check
+var _ usecase.TableDDLGetter = (*tableDDLGetter)(nil)
+
+type tableDDLGetter struct {
+	repository.TableDDLGetter
+}
+
+// NewTableDDLGetter create new TableDDLGetter.
+func NewTableDDLGetter(
+	g repository.TableDDLGetter,
+) usecase.TableDDLGetter {
+	return &tableDDLGetter{
+		TableDDLGetter: g,
+	}
+}
+
+// GetTableDDL gets a table's DDL information.
+func (r *tableDDLGetter) GetTableDDL(ctx context.Context, tableName string) ([]*model.Table, error) {
+	return r.TableDDLGetter.GetTableDDL(ctx, tableName)
+}

--- a/interactor/mock/in_memory.go
+++ b/interactor/mock/in_memory.go
@@ -204,3 +204,66 @@ func (c *MockSQLExecutorExecuteSQLCall) DoAndReturn(f func(context.Context, *mod
 	c.Call = c.Call.DoAndReturn(f)
 	return c
 }
+
+// MockTableDDLGetter is a mock of TableDDLGetter interface.
+type MockTableDDLGetter struct {
+	ctrl     *gomock.Controller
+	recorder *MockTableDDLGetterMockRecorder
+	isgomock struct{}
+}
+
+// MockTableDDLGetterMockRecorder is the mock recorder for MockTableDDLGetter.
+type MockTableDDLGetterMockRecorder struct {
+	mock *MockTableDDLGetter
+}
+
+// NewMockTableDDLGetter creates a new mock instance.
+func NewMockTableDDLGetter(ctrl *gomock.Controller) *MockTableDDLGetter {
+	mock := &MockTableDDLGetter{ctrl: ctrl}
+	mock.recorder = &MockTableDDLGetterMockRecorder{mock}
+	return mock
+}
+
+// EXPECT returns an object that allows the caller to indicate expected use.
+func (m *MockTableDDLGetter) EXPECT() *MockTableDDLGetterMockRecorder {
+	return m.recorder
+}
+
+// GetTableDDL mocks base method.
+func (m *MockTableDDLGetter) GetTableDDL(ctx context.Context, tableName string) ([]*model.Table, error) {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "GetTableDDL", ctx, tableName)
+	ret0, _ := ret[0].([]*model.Table)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
+}
+
+// GetTableDDL indicates an expected call of GetTableDDL.
+func (mr *MockTableDDLGetterMockRecorder) GetTableDDL(ctx, tableName any) *MockTableDDLGetterGetTableDDLCall {
+	mr.mock.ctrl.T.Helper()
+	call := mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetTableDDL", reflect.TypeOf((*MockTableDDLGetter)(nil).GetTableDDL), ctx, tableName)
+	return &MockTableDDLGetterGetTableDDLCall{Call: call}
+}
+
+// MockTableDDLGetterGetTableDDLCall wrap *gomock.Call
+type MockTableDDLGetterGetTableDDLCall struct {
+	*gomock.Call
+}
+
+// Return rewrite *gomock.Call.Return
+func (c *MockTableDDLGetterGetTableDDLCall) Return(arg0 []*model.Table, arg1 error) *MockTableDDLGetterGetTableDDLCall {
+	c.Call = c.Call.Return(arg0, arg1)
+	return c
+}
+
+// Do rewrite *gomock.Call.Do
+func (c *MockTableDDLGetterGetTableDDLCall) Do(f func(context.Context, string) ([]*model.Table, error)) *MockTableDDLGetterGetTableDDLCall {
+	c.Call = c.Call.Do(f)
+	return c
+}
+
+// DoAndReturn rewrite *gomock.Call.DoAndReturn
+func (c *MockTableDDLGetterGetTableDDLCall) DoAndReturn(f func(context.Context, string) ([]*model.Table, error)) *MockTableDDLGetterGetTableDDLCall {
+	c.Call = c.Call.DoAndReturn(f)
+	return c
+}

--- a/interactor/mock/persistence.go
+++ b/interactor/mock/persistence.go
@@ -144,32 +144,32 @@ func (c *MockTablesGetterGetTablesCall) DoAndReturn(f func(context.Context) ([]*
 	return c
 }
 
-// MockTableDDLGetter is a mock of TableDDLGetter interface.
-type MockTableDDLGetter struct {
+// MockTableDDLInRemoteGetter is a mock of TableDDLInRemoteGetter interface.
+type MockTableDDLInRemoteGetter struct {
 	ctrl     *gomock.Controller
-	recorder *MockTableDDLGetterMockRecorder
+	recorder *MockTableDDLInRemoteGetterMockRecorder
 	isgomock struct{}
 }
 
-// MockTableDDLGetterMockRecorder is the mock recorder for MockTableDDLGetter.
-type MockTableDDLGetterMockRecorder struct {
-	mock *MockTableDDLGetter
+// MockTableDDLInRemoteGetterMockRecorder is the mock recorder for MockTableDDLInRemoteGetter.
+type MockTableDDLInRemoteGetterMockRecorder struct {
+	mock *MockTableDDLInRemoteGetter
 }
 
-// NewMockTableDDLGetter creates a new mock instance.
-func NewMockTableDDLGetter(ctrl *gomock.Controller) *MockTableDDLGetter {
-	mock := &MockTableDDLGetter{ctrl: ctrl}
-	mock.recorder = &MockTableDDLGetterMockRecorder{mock}
+// NewMockTableDDLInRemoteGetter creates a new mock instance.
+func NewMockTableDDLInRemoteGetter(ctrl *gomock.Controller) *MockTableDDLInRemoteGetter {
+	mock := &MockTableDDLInRemoteGetter{ctrl: ctrl}
+	mock.recorder = &MockTableDDLInRemoteGetterMockRecorder{mock}
 	return mock
 }
 
 // EXPECT returns an object that allows the caller to indicate expected use.
-func (m *MockTableDDLGetter) EXPECT() *MockTableDDLGetterMockRecorder {
+func (m *MockTableDDLInRemoteGetter) EXPECT() *MockTableDDLInRemoteGetterMockRecorder {
 	return m.recorder
 }
 
 // GetTableDDL mocks base method.
-func (m *MockTableDDLGetter) GetTableDDL(ctx context.Context, tableName string) ([]*model.Table, error) {
+func (m *MockTableDDLInRemoteGetter) GetTableDDL(ctx context.Context, tableName string) ([]*model.Table, error) {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "GetTableDDL", ctx, tableName)
 	ret0, _ := ret[0].([]*model.Table)
@@ -178,31 +178,31 @@ func (m *MockTableDDLGetter) GetTableDDL(ctx context.Context, tableName string) 
 }
 
 // GetTableDDL indicates an expected call of GetTableDDL.
-func (mr *MockTableDDLGetterMockRecorder) GetTableDDL(ctx, tableName any) *MockTableDDLGetterGetTableDDLCall {
+func (mr *MockTableDDLInRemoteGetterMockRecorder) GetTableDDL(ctx, tableName any) *MockTableDDLInRemoteGetterGetTableDDLCall {
 	mr.mock.ctrl.T.Helper()
-	call := mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetTableDDL", reflect.TypeOf((*MockTableDDLGetter)(nil).GetTableDDL), ctx, tableName)
-	return &MockTableDDLGetterGetTableDDLCall{Call: call}
+	call := mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetTableDDL", reflect.TypeOf((*MockTableDDLInRemoteGetter)(nil).GetTableDDL), ctx, tableName)
+	return &MockTableDDLInRemoteGetterGetTableDDLCall{Call: call}
 }
 
-// MockTableDDLGetterGetTableDDLCall wrap *gomock.Call
-type MockTableDDLGetterGetTableDDLCall struct {
+// MockTableDDLInRemoteGetterGetTableDDLCall wrap *gomock.Call
+type MockTableDDLInRemoteGetterGetTableDDLCall struct {
 	*gomock.Call
 }
 
 // Return rewrite *gomock.Call.Return
-func (c *MockTableDDLGetterGetTableDDLCall) Return(arg0 []*model.Table, arg1 error) *MockTableDDLGetterGetTableDDLCall {
+func (c *MockTableDDLInRemoteGetterGetTableDDLCall) Return(arg0 []*model.Table, arg1 error) *MockTableDDLInRemoteGetterGetTableDDLCall {
 	c.Call = c.Call.Return(arg0, arg1)
 	return c
 }
 
 // Do rewrite *gomock.Call.Do
-func (c *MockTableDDLGetterGetTableDDLCall) Do(f func(context.Context, string) ([]*model.Table, error)) *MockTableDDLGetterGetTableDDLCall {
+func (c *MockTableDDLInRemoteGetterGetTableDDLCall) Do(f func(context.Context, string) ([]*model.Table, error)) *MockTableDDLInRemoteGetterGetTableDDLCall {
 	c.Call = c.Call.Do(f)
 	return c
 }
 
 // DoAndReturn rewrite *gomock.Call.DoAndReturn
-func (c *MockTableDDLGetterGetTableDDLCall) DoAndReturn(f func(context.Context, string) ([]*model.Table, error)) *MockTableDDLGetterGetTableDDLCall {
+func (c *MockTableDDLInRemoteGetterGetTableDDLCall) DoAndReturn(f func(context.Context, string) ([]*model.Table, error)) *MockTableDDLInRemoteGetterGetTableDDLCall {
 	c.Call = c.Call.DoAndReturn(f)
 	return c
 }

--- a/interactor/persistence.go
+++ b/interactor/persistence.go
@@ -65,22 +65,22 @@ func (m *tablesGetter) GetTables(ctx context.Context) ([]*model.Table, error) {
 }
 
 // _ interface implementation check
-var _ usecase.TableDDLGetter = (*tableDDLGetter)(nil)
+var _ usecase.TableDDLInRemoteGetter = (*tableDDLInRemoteGetter)(nil)
 
-type tableDDLGetter struct {
-	repository.TableDDLGetter
+type tableDDLInRemoteGetter struct {
+	repository.TableDDLInRemoteGetter
 }
 
-// NewTableDDLGetter creates a new TableDDLGetter.
-func NewTableDDLGetter(
-	tdg repository.TableDDLGetter,
-) usecase.TableDDLGetter {
-	return &tableDDLGetter{
-		TableDDLGetter: tdg,
+// NewTableDDLInRemoteGetter creates a new TableDDLGetter.
+func NewTableDDLInRemoteGetter(
+	tdg repository.TableDDLInRemoteGetter,
+) usecase.TableDDLInRemoteGetter {
+	return &tableDDLInRemoteGetter{
+		TableDDLInRemoteGetter: tdg,
 	}
 }
 
 // GetTableDDL gets DDL information of a table in MySQL database.
-func (m *tableDDLGetter) GetTableDDL(ctx context.Context, tableName string) ([]*model.Table, error) {
-	return m.TableDDLGetter.GetTableDDL(ctx, tableName)
+func (m *tableDDLInRemoteGetter) GetTableDDL(ctx context.Context, tableName string) ([]*model.Table, error) {
+	return m.TableDDLInRemoteGetter.GetTableDDL(ctx, tableName)
 }

--- a/interactor/wire.go
+++ b/interactor/wire.go
@@ -14,5 +14,6 @@ var Set = wire.NewSet(
 	NewHistoryTableCreator,
 	NewHistoryCreator,
 	NewHistoryLister,
+	NewTableDDLInRemoteGetter,
 	NewTableDDLGetter,
 )

--- a/usecase/in_memory.go
+++ b/usecase/in_memory.go
@@ -29,6 +29,11 @@ type (
 	SQLExecutor interface {
 		ExecuteSQL(ctx context.Context, sql *model.SQL) (*ExecuteSQLOutput, error)
 	}
+
+	// TableDDLGetter gets a table's DDL information.
+	TableDDLGetter interface {
+		GetTableDDL(ctx context.Context, tableName string) ([]*model.Table, error)
+	}
 )
 
 // NewExecuteSQLOutput creates a new ExecuteSQLOutput.

--- a/usecase/persistence.go
+++ b/usecase/persistence.go
@@ -25,9 +25,9 @@ type (
 		GetTables(ctx context.Context) ([]*model.Table, error)
 	}
 
-	// TableDDLGetter is an interface for retrieving a table's DDL information,
+	// TableDDLInRemoteGetter is an interface for retrieving a table's DDL information,
 	// including columns, data types, precision, nullability, default values, primary key status, etc.
-	TableDDLGetter interface {
+	TableDDLInRemoteGetter interface {
 		GetTableDDL(ctx context.Context, tableName string) ([]*model.Table, error)
 	}
 )


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - The Text User Interface now offers enhanced table schema retrieval. Users can view detailed table definitions (DDL) whether connected to a remote database or working locally, providing a streamlined and robust experience when exploring database structures.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->